### PR TITLE
Feature/#4-2 존재하지 않는 게시물 접근에 대한 예외처리

### DIFF
--- a/src/main/java/com/jscode/demoApp/config/WebMvcConfig.java
+++ b/src/main/java/com/jscode/demoApp/config/WebMvcConfig.java
@@ -1,0 +1,26 @@
+package com.jscode.demoApp.config;
+
+import com.jscode.demoApp.error.resolver.CustomExceptionResolver;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.HandlerExceptionResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.List;
+
+@Configuration
+public class WebMvcConfig implements WebMvcConfigurer {
+
+    /* 현재 미사용
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+
+    }*/
+
+    /* @ExceptionHandler를 사용하므로 customResolver는 사용하지 않기로 하였음.
+    @Override
+    public void extendHandlerExceptionResolvers(List<HandlerExceptionResolver> resolvers) {
+        resolvers.add(new CustomExceptionResolver());
+    }
+    */
+
+}

--- a/src/main/java/com/jscode/demoApp/controller/ArticleController.java
+++ b/src/main/java/com/jscode/demoApp/controller/ArticleController.java
@@ -25,6 +25,7 @@ import java.util.Map;
 public class ArticleController {
 
     private final ArticleService articleService;
+
     @GetMapping("/articles")
     public ResponseEntity getArticles(@RequestParam(name="searchType", required = false)SearchType searchType,
                                                                 @RequestParam(name="searchKeyword", required = false, defaultValue = "")String searchKeyword){
@@ -37,12 +38,7 @@ public class ArticleController {
 
     @GetMapping("/articles/{id}")
     public ResponseEntity getArticle(@PathVariable Long id){
-        ArticleResponseDto articleResponseDto = null;
-        try{
-            articleResponseDto = ArticleResponseDto.fromDto(articleService.getArticle(id));
-        }catch(EntityNotFoundException e){
-            return ResponseEntity.notFound().build();
-        }
+        ArticleResponseDto articleResponseDto = ArticleResponseDto.fromDto(articleService.getArticle(id));
         return ResponseEntity.ok(articleResponseDto);
     }
 
@@ -70,22 +66,13 @@ public class ArticleController {
 
     @PutMapping("/articles/{id}")
     public ResponseEntity updateArticle(@RequestBody ArticleRequestDto articleRequestDto){
-        ArticleResponseDto updatedArticleDto = null;
-        try{
-            updatedArticleDto = ArticleResponseDto.fromDto(articleService.updateArticle(articleRequestDto.toArticleDto()));
-        }catch(EntityNotFoundException e){
-            return ResponseEntity.notFound().build();
-        }
+        ArticleResponseDto updatedArticleDto = ArticleResponseDto.fromDto(articleService.updateArticle(articleRequestDto.toArticleDto()));
         return ResponseEntity.ok(updatedArticleDto);
     }
 
     @DeleteMapping("/articles/{id}")
     public ResponseEntity deleteArticle(@PathVariable Long id){
-        try{
-            articleService.deleteArticle(id);
-        }catch (EntityNotFoundException e){
-            return ResponseEntity.notFound().build();
-        }
+        articleService.deleteArticle(id);
         return ResponseEntity.ok("게시물이 삭제되었습니다.");
     }
 

--- a/src/main/java/com/jscode/demoApp/error/advice/ArticleAdvice.java
+++ b/src/main/java/com/jscode/demoApp/error/advice/ArticleAdvice.java
@@ -1,0 +1,29 @@
+package com.jscode.demoApp.error.advice;
+
+import com.jscode.demoApp.controller.ArticleController;
+import org.hibernate.TypeMismatchException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import javax.persistence.EntityNotFoundException;
+
+@RestControllerAdvice
+public class ArticleAdvice {
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    @ExceptionHandler(EntityNotFoundException.class)
+    public String entityExHandler(EntityNotFoundException ex){
+        //todo: API인 점을 고려해서 문자열보다는 부호화된 코드를 보내는 걸로 refactor필요
+        return ex.getMessage();
+    }
+
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    public String typeMismatchHandler(HttpMessageNotReadableException ex){
+
+        return "JSON형식으로 보내주세요.";
+    }
+}

--- a/src/main/java/com/jscode/demoApp/error/resolver/CustomExceptionResolver.java
+++ b/src/main/java/com/jscode/demoApp/error/resolver/CustomExceptionResolver.java
@@ -1,0 +1,49 @@
+package com.jscode.demoApp.error.resolver;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.MediaType;
+import org.springframework.web.servlet.HandlerExceptionResolver;
+import org.springframework.web.servlet.ModelAndView;
+
+import javax.persistence.EntityNotFoundException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+@Slf4j
+public class CustomExceptionResolver implements HandlerExceptionResolver {
+    private final ObjectMapper objectMapper = new ObjectMapper();
+    @Override
+    public ModelAndView resolveException(HttpServletRequest request,
+                                         HttpServletResponse response,
+                                         Object handler, Exception ex) {
+        try {
+            if(ex instanceof EntityNotFoundException) {
+                log.info("Entity Not Found Exception");
+                String acceptHeader = request.getHeader("accept");
+                response.setStatus(HttpServletResponse.SC_NOT_FOUND);
+                if(MediaType.APPLICATION_JSON_VALUE.equals(acceptHeader)){
+                    Map<String, Object> errorResult = new HashMap<>();
+                    errorResult.put("ex", ex.getClass());
+                    errorResult.put("message", ex.getMessage());
+                    String result = objectMapper.writeValueAsString(errorResult);
+
+                    response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+                    response.setCharacterEncoding("UTF-8");
+                    response.getWriter().println(result);
+                    return new ModelAndView();
+                } else{
+                    //todo : 에러 뷰페이지 없음
+                    return new ModelAndView("error/500");
+                }
+            }
+        }catch (IOException e) {
+            log.error("ExceptionResolver Error : {}", e.getMessage());
+        }
+
+        return null;
+    }
+}

--- a/src/main/java/com/jscode/demoApp/service/ArticleService.java
+++ b/src/main/java/com/jscode/demoApp/service/ArticleService.java
@@ -6,7 +6,9 @@ import com.jscode.demoApp.dto.ArticleDto;
 import com.jscode.demoApp.repository.ArticleRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
+import org.springframework.web.server.ResponseStatusException;
 import org.thymeleaf.util.StringUtils;
 
 import javax.persistence.EntityNotFoundException;
@@ -26,6 +28,8 @@ public class ArticleService {
         Article article = articleRepository.findById(id)
                 .orElseThrow(() -> {
             throw new EntityNotFoundException("게시글이 존재하지 않습니다");
+            //아래 코드로도 예외처리 가능
+            //throw new ResponseStatusException(HttpStatus.NOT_FOUND, "게시글이 존재하지 않습니다.", new EntityNotFoundException());
         });
         return ArticleDto.fromEntity(article);
     }

--- a/src/test/java/com/jscode/demoApp/controller/ArticleControllerTest.java
+++ b/src/test/java/com/jscode/demoApp/controller/ArticleControllerTest.java
@@ -61,7 +61,8 @@ public class ArticleControllerTest {
 
         given(articleService.getArticle(any(Long.class))).willThrow(new EntityNotFoundException());
 
-        mvc.perform(get("/articles/100"))
+        mvc.perform(get("/articles/100")
+                        .accept(MediaType.APPLICATION_JSON_VALUE))
                 .andExpect(status().isNotFound());
     }
 


### PR DESCRIPTION
1. 조회하고자 하는 게시물 Id가 존재하지 않으면 에러 메시지 전시
2.  삭제하고자 하는 게시물 Id가 존재하지 않으면 에러 메시지 전시
-> id가 존재하지 않을 경우 ArticleService에서 EntityNotFoundException발생 시키고 ArticleAdvice에서 ExceptionHandler로 일괄처리

To 리뷰어 : 
- service레이어 코드에 throw Exception부분이 중복되고 있습니다. 
   repository는 db와 직접 연결되는 부분이고 게시물이 없는 것에 대한 처리는 서비스 레이어가 담당하는 게 낫다고 생각해서 현재와 같이 작성했습니다. 다만 이렇게 하니 코드가 비효율적으로 구현되는 것 같습니다. 
  코드의 간결성을 위해 repository에 예외를 던지게 할지, 아니면 각 계층별 역할을 고려해 service레이어에서 예외를 던지게 하는 게 나을지 피드백 부탁드립니다.
@jaeseongDev @mog-hi 


this closes #6 