### PR TITLE
Feature/#4-3 TITLE 검색 조건인 경우 입력 유효성 검사(글자길이 1이상)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -175,5 +175,8 @@ gradle-app.setting
 # Java heap dump
 *.hprof
 
-*application*.properties
+
+*.properties
 # End of https://www.toptal.com/developers/gitignore/api/windows,macos,gradle,intellij+all
+
+

--- a/src/main/java/com/jscode/demoApp/controller/validator/SearchValidator.java
+++ b/src/main/java/com/jscode/demoApp/controller/validator/SearchValidator.java
@@ -1,0 +1,29 @@
+package com.jscode.demoApp.controller.validator;
+
+import com.jscode.demoApp.constant.SearchType;
+import com.jscode.demoApp.dto.request.SearchRequestDto;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.validation.Errors;
+import org.springframework.validation.Validator;
+
+@Component
+@Slf4j
+public class SearchValidator implements Validator {
+    @Override
+    public boolean supports(Class<?> clazz) {
+        log.info("customvalidator : {}", clazz.getClass());
+        return SearchRequestDto.class.isAssignableFrom(clazz);
+    }
+
+    @Override
+    public void validate(Object target, Errors errors) {
+        SearchRequestDto searchRequestDto = (SearchRequestDto) target;
+        log.info("customvalidator : {}", searchRequestDto);
+        if(searchRequestDto.getSearchType() != null){
+            if(searchRequestDto.getSearchKeyword().length() < 1){
+                errors.rejectValue("searchKeyword", "Size" ,"검색 키워드는 1글자 이상입니다.");
+            }
+        }
+    }
+}

--- a/src/main/java/com/jscode/demoApp/dto/request/SearchRequestDto.java
+++ b/src/main/java/com/jscode/demoApp/dto/request/SearchRequestDto.java
@@ -1,0 +1,20 @@
+package com.jscode.demoApp.dto.request;
+
+import com.jscode.demoApp.constant.SearchType;
+import lombok.*;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@ToString
+@Setter
+public class SearchRequestDto {
+
+    SearchType searchType;
+
+    String searchKeyword;
+}

--- a/src/main/java/com/jscode/demoApp/error/advice/ArticleAdvice.java
+++ b/src/main/java/com/jscode/demoApp/error/advice/ArticleAdvice.java
@@ -11,7 +11,7 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 import javax.persistence.EntityNotFoundException;
 
-@RestControllerAdvice
+@RestControllerAdvice(assignableTypes = ArticleController.class)
 public class ArticleAdvice {
     @ResponseStatus(HttpStatus.NOT_FOUND)
     @ExceptionHandler(EntityNotFoundException.class)

--- a/src/main/java/com/jscode/demoApp/error/advice/ArticleAdvice.java
+++ b/src/main/java/com/jscode/demoApp/error/advice/ArticleAdvice.java
@@ -20,10 +20,20 @@ public class ArticleAdvice {
         return ex.getMessage();
     }
 
+    //@RequestBody에 text/html형식 데이터가 올 때
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     @ExceptionHandler(HttpMessageNotReadableException.class)
-    public String typeMismatchHandler(HttpMessageNotReadableException ex){
+    public String messageNotReadableExHandler(HttpMessageNotReadableException ex){
 
         return "JSON형식으로 보내주세요.";
+    }
+
+    //검색 타입을 잘못지정하였을 때
+
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ExceptionHandler
+    public void illegalArgumentExHandler(IllegalArgumentException ex){
+
+        throw new IllegalStateException("유효하지 않은 입력입니다.");
     }
 }

--- a/src/main/java/com/jscode/demoApp/service/ArticleService.java
+++ b/src/main/java/com/jscode/demoApp/service/ArticleService.java
@@ -3,19 +3,16 @@ package com.jscode.demoApp.service;
 import com.jscode.demoApp.constant.SearchType;
 import com.jscode.demoApp.domain.Article;
 import com.jscode.demoApp.dto.ArticleDto;
+import com.jscode.demoApp.dto.request.SearchRequestDto;
 import com.jscode.demoApp.repository.ArticleRepository;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
-import org.springframework.web.server.ResponseStatusException;
-import org.thymeleaf.util.StringUtils;
 
 import javax.persistence.EntityNotFoundException;
 import javax.transaction.Transactional;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
+
 
 @Service
 @RequiredArgsConstructor
@@ -34,13 +31,13 @@ public class ArticleService {
         return ArticleDto.fromEntity(article);
     }
 
-    public List<ArticleDto> searchArticle(SearchType searchType, String searchKeyword){
+    public List<ArticleDto> searchArticle(SearchRequestDto searchRequestDto){
         List<Article> articles = new ArrayList<>();
 
-        if(searchType == null || StringUtils.isEmptyOrWhitespace(searchKeyword)){
+        if(searchRequestDto.getSearchType() == null){
             articles = articleRepository.findAll();
-        }else if(searchType == SearchType.TITLE){
-            articles = articleRepository.findByTitle(searchKeyword);
+        }else if(searchRequestDto.getSearchType() == SearchType.TITLE){
+            articles = articleRepository.findByTitle(searchRequestDto.getSearchKeyword());
         }else{ //ToDo : 향후 구현
             articles = articleRepository.findAll();
         }

--- a/src/main/java/com/jscode/demoApp/service/ArticleService.java
+++ b/src/main/java/com/jscode/demoApp/service/ArticleService.java
@@ -63,6 +63,7 @@ public class ArticleService {
     }
 
     public void deleteArticle(Long id){
+        //Todo : findById() 메소드 자체에서 값이 없을 경우 EntityNotFoundException을 throw하면 코드 중복을 줄일 수 있을 듯 하다.
         Article article = articleRepository.findById(id)
                 .orElseThrow(() -> {
                     throw new EntityNotFoundException("해당 게시글은 존재하지 않습니다");

--- a/src/test/java/com/jscode/demoApp/controller/ArticleControllerTest.java
+++ b/src/test/java/com/jscode/demoApp/controller/ArticleControllerTest.java
@@ -1,9 +1,12 @@
 package com.jscode.demoApp.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.jscode.demoApp.constant.SearchType;
+import com.jscode.demoApp.controller.validator.SearchValidator;
 import com.jscode.demoApp.domain.Article;
 import com.jscode.demoApp.dto.ArticleDto;
 import com.jscode.demoApp.dto.request.ArticleRequestDto;
+import com.jscode.demoApp.dto.request.SearchRequestDto;
 import com.jscode.demoApp.dto.response.ArticleResponseDto;
 import com.jscode.demoApp.service.ArticleService;
 import org.junit.jupiter.api.DisplayName;
@@ -14,6 +17,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.util.LinkedMultiValueMap;
@@ -37,6 +41,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @WebMvcTest(ArticleController.class)
+@Import(SearchValidator.class)
 public class ArticleControllerTest {
     @Autowired MockMvc mvc;
 
@@ -44,7 +49,7 @@ public class ArticleControllerTest {
     ArticleService articleService;
 
     @Test
-    @DisplayName("[GET]특정 게시글 조회 테스트(게시글 O)")
+    @DisplayName("[GET]게시글 Id 이용 조회 테스트(게시글 O)")
     public void getArticleTest() throws Exception {
         Long articleId = 1L;
         given(articleService.getArticle(articleId)).willReturn(new ArticleDto(articleId, "title", "content"));
@@ -58,7 +63,7 @@ public class ArticleControllerTest {
     }
 
     @Test
-    @DisplayName("[GET]특정 게시글 조회 테스트(게시글 X)")
+    @DisplayName("[GET]게시글 Id 이용 조회 테스트(게시글 X)")
     public void getArticleFailTest() throws Exception {
 
         given(articleService.getArticle(any(Long.class))).willThrow(new EntityNotFoundException());
@@ -67,6 +72,78 @@ public class ArticleControllerTest {
                         .accept(MediaType.APPLICATION_JSON_VALUE))
                 .andExpect(status().isNotFound());
     }
+
+    @Test
+    @DisplayName("[GET]게시글 검색 테스트(SearchType Null)")
+    public void getArticleByNoneTest() throws Exception {
+        SearchRequestDto dto = new SearchRequestDto(null, null);
+        given(articleService.searchArticle(dto)).willReturn(new ArrayList<ArticleDto>());
+
+        mvc.perform(get("/articles"))
+                .andExpect(status().isOk())
+                .andDo(print());
+    }
+
+    @Test
+    @DisplayName("[GET]게시글 유효하지 않은 검색 테스트(Invalid SearchType1)")
+    public void getArticleByInvalidSearchType() throws Exception {
+        MultiValueMap<String, String> param = new LinkedMultiValueMap<>();
+        param.add("searchType", "CONTENT");
+        param.add("searchKeyword", "");
+
+
+        given(articleService.searchArticle(any(SearchRequestDto.class))).willReturn(new ArrayList<ArticleDto>());
+
+        mvc.perform(get("/articles")
+                        .queryParams(param))
+                .andExpect(status().isBadRequest())
+                .andDo(print());
+    }
+
+    @Test
+    @DisplayName("[GET]게시글 유효하지 않은 검색 테스트(Invalid SearchType2)")
+    public void getArticleByInvalidSearchTypeAndShort() throws Exception {
+        MultiValueMap<String, String> param = new LinkedMultiValueMap<>();
+        param.add("searchType", "TITLE1");
+        param.add("searchKeyword", "aaa");
+
+        given(articleService.searchArticle(any(SearchRequestDto.class))).willReturn(new ArrayList<ArticleDto>());
+
+        mvc.perform(get("/articles")
+                        .queryParams(param))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.*", hasSize(1)))
+                .andDo(print());
+    }
+
+    @Test
+    @DisplayName("[GET]게시글 제목 검색 테스트(SearchType TITLE)")
+    public void getArticleByTitleTest() throws Exception {
+        MultiValueMap<String, String> param = new LinkedMultiValueMap<>();
+        param.add("searchType", "TITLE");
+        param.add("searchKeyword", "wow");
+        given(articleService.searchArticle(any(SearchRequestDto.class))).willReturn(new ArrayList<ArticleDto>());
+
+        mvc.perform(get("/articles")
+                        .queryParams(param))
+                .andExpect(status().isOk())
+                .andDo(print());
+    }
+
+    @Test
+    @DisplayName("[GET]게시글 제목 검색 실패 테스트(SearchType TITLE)")
+    public void getArticleByTitleLengthFailTest() throws Exception {
+        MultiValueMap<String, String> param = new LinkedMultiValueMap<>();
+        param.add("searchType", "TITLE");
+        param.add("searchKeyword", "");
+        given(articleService.searchArticle(any(SearchRequestDto.class))).willReturn(new ArrayList<ArticleDto>());
+
+        mvc.perform(get("/articles")
+                        .queryParams(param))
+                .andExpect(status().isBadRequest())
+                .andDo(print());
+    }
+
 
     @Test
     @DisplayName("[POST]게시글 생성 테스트(정상)")

--- a/src/test/java/com/jscode/demoApp/controller/ArticleControllerTest.java
+++ b/src/test/java/com/jscode/demoApp/controller/ArticleControllerTest.java
@@ -176,6 +176,26 @@ public class ArticleControllerTest {
                 .andDo(print());
     }
 
+    @DisplayName("[PUT]게시물 수정 테스트(게시글 ID에 String 입력)")
+    @Test
+    public void updateArticleWrongIdTypeFailTest() throws Exception{
+        ObjectMapper request = new ObjectMapper();
+        Map<String, String> param = new HashMap<>();
+        param.put("id", "string");
+        param.put("title", "titl");
+        param.put("content", "content");
+
+
+        given(articleService.updateArticle(any(ArticleDto.class))).willThrow(new EntityNotFoundException());
+
+        mvc.perform(put("/articles/1")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(request.writeValueAsString(param)))
+                .andExpect(status().isBadRequest())
+                .andExpect(content().string("JSON형식으로 보내주세요."))
+                .andDo(print());
+    }
+
     @DisplayName("[Common] DataBindingError 테스트 ")
     @Test()
     void requestBodyBindingErrorTest() throws Exception {

--- a/src/test/java/com/jscode/demoApp/repository/ArticleRepositoryTest.java
+++ b/src/test/java/com/jscode/demoApp/repository/ArticleRepositoryTest.java
@@ -36,7 +36,7 @@ public class ArticleRepositoryTest {
             articleRepository.save(article);
         }
     }
-    @DisplayName("게시물 조회 테스트")
+    @DisplayName("[R]게시물 조회 테스트")
     @Test
     @Transactional
     public void articleFindTest(){
@@ -52,19 +52,18 @@ public class ArticleRepositoryTest {
         Assertions.assertThat(article).isNotNull();
     }
 
-    @DisplayName("전체 게시물 조회 테스트")
+    @DisplayName("[R]전체 게시물 조회 테스트")
     @Test
     @Transactional
     public void articleFindAllTest(){
-        saveArticles();
-        saveArticles();
+
         List<Article> articles = articleRepository.findAll();
         System.out.println("========");
         articles.stream().forEach(System.out::println);
         Assertions.assertThat(articles.size()).isEqualTo(10);
     }
 
-    @DisplayName("게시물 삭제 테스트")
+    @DisplayName("[D]게시물 삭제 테스트")
     @Test
     @Transactional
     public void deleteArticleTest(){
@@ -79,7 +78,7 @@ public class ArticleRepositoryTest {
         Assertions.assertThat(article.isPresent()).isFalse();
     }
 
-    @DisplayName("제목 검색 테스트")
+    @DisplayName("[R]제목 검색 테스트")
     @Test
     @Transactional
     public void findByTitleTest(){

--- a/src/test/java/com/jscode/demoApp/service/ArticleServiceIETest.java
+++ b/src/test/java/com/jscode/demoApp/service/ArticleServiceIETest.java
@@ -3,6 +3,7 @@ package com.jscode.demoApp.service;
 import com.jscode.demoApp.constant.SearchType;
 import com.jscode.demoApp.domain.Article;
 import com.jscode.demoApp.dto.ArticleDto;
+import com.jscode.demoApp.dto.request.SearchRequestDto;
 import com.jscode.demoApp.repository.ArticleRepository;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
@@ -12,6 +13,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.context.SpringBootTest;
 
@@ -43,7 +45,7 @@ public class ArticleServiceIETest {
         }
     }
 
-    @DisplayName("id로 게시글 찾기 테스트")
+    @DisplayName("[조회] id로 게시글 찾기 테스트")
     @Test
     public void getArticleTest(){
         System.out.println(articleRepository);
@@ -59,7 +61,7 @@ public class ArticleServiceIETest {
         Assertions.assertThat(findArticle.getTitle()).isEqualTo(title);
     }
 
-    @DisplayName("게시글 찾기 실패 테스트")
+    @DisplayName("[조회] 게시글 찾기 실패 테스트")
     @Test
     public void getArticleFailTest(){
         Assertions.assertThatThrownBy(() -> {
@@ -67,7 +69,7 @@ public class ArticleServiceIETest {
                 .isInstanceOf(EntityNotFoundException.class);
     }
 
-    @DisplayName("전체 게시글 찾기 테스트")
+    @DisplayName("[조회] 전체 게시글 조회 테스트")
     @Test
     public void getAllArticleTest(){
         saveArticles();
@@ -76,7 +78,7 @@ public class ArticleServiceIETest {
         Assertions.assertThat(articles.size()).isEqualTo(10);
     }
 
-    @DisplayName("게시글 삭제 테스트")
+    @DisplayName("[삭제] 게시글 삭제 테스트")
     @Test
     public void deleteArticleTest(){
         saveArticles();
@@ -92,7 +94,8 @@ public class ArticleServiceIETest {
         Assertions.assertThat(articles.size()).isEqualTo(10);
     }
 
-    @DisplayName("게시글 수정 테스트")
+
+    @DisplayName("[수정] 게시글 수정 테스트")
     @Test
     public void updateArticleTest(){
         String title = "제목 수정 전";
@@ -109,7 +112,7 @@ public class ArticleServiceIETest {
 
     }
 
-    @DisplayName("게시물 검색 테스트")
+    @DisplayName("[검색] 게시물 검색 테스트")
     @Test
     public void articleSearchTest(){
         String title = "찾을 제목";
@@ -117,8 +120,11 @@ public class ArticleServiceIETest {
 
         IntStream.range(0, 5).forEach(i -> articleService.createArticle(new ArticleDto(null, title, content)));
 
-        List<ArticleDto> articles = articleService.searchArticle(SearchType.TITLE, title);
+
+        List<ArticleDto> articles = articleService.searchArticle(new SearchRequestDto(SearchType.TITLE, title));
         Assertions.assertThat(articles.size()).isEqualTo(5);
 
     }
+
+
 }

--- a/src/test/java/com/jscode/demoApp/service/ArticleServiceUnitTest.java
+++ b/src/test/java/com/jscode/demoApp/service/ArticleServiceUnitTest.java
@@ -3,11 +3,15 @@ package com.jscode.demoApp.service;
 import com.jscode.demoApp.constant.SearchType;
 import com.jscode.demoApp.domain.Article;
 import com.jscode.demoApp.dto.ArticleDto;
+import com.jscode.demoApp.dto.request.SearchRequestDto;
 import com.jscode.demoApp.repository.ArticleRepository;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -15,7 +19,9 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import javax.persistence.EntityNotFoundException;
 import java.util.ArrayList;
 import java.util.Optional;
+import java.util.stream.Stream;
 
+import static org.junit.jupiter.params.provider.Arguments.arguments;
 import static org.mockito.BDDMockito.*;
 import static org.mockito.Mockito.when;
 
@@ -25,7 +31,7 @@ public class ArticleServiceUnitTest {
     @Mock private ArticleRepository articleRepository;
 
     @Test
-    @DisplayName("id로 게시글 찾기 테스트")
+    @DisplayName("[검색]id로 게시글 찾기 테스트(실패)")
     public void findByIdFailTest(){
         Long id = 1L;
         given(articleRepository.findById(id)).willReturn(Optional.empty());
@@ -35,7 +41,7 @@ public class ArticleServiceUnitTest {
     }
 
     @Test
-    @DisplayName("저장 테스트")
+    @DisplayName("[저장]저장 테스트")
     public void saveTest(){
         Article article = Article.builder().title("제목").content("내용").build();
         given(articleRepository.save(any(Article.class))).willReturn(article);
@@ -44,14 +50,34 @@ public class ArticleServiceUnitTest {
         then(articleRepository).should().save(any(Article.class));
     }
 
-    @Test
-    @DisplayName("검색 테스트")
-    public void searchTest(){
-        given(articleRepository.findByTitle(any(String.class))).willReturn(new ArrayList<Article>());
-        articleService.searchArticle(SearchType.TITLE, "searchKeyworkd");
-        articleService.searchArticle(null, "searchKeyworkd");
+    @ParameterizedTest(name = "[{index}] message : {0}({1})")
+    @MethodSource("searchByTitleTest")
+    @DisplayName("[검색]검색 테스트")
+    public void searchByTest(String message, SearchType searchType, String searchKeyword){
+        SearchRequestDto param = new SearchRequestDto(searchType, searchKeyword);
 
-        then(articleRepository).should().findByTitle(any(String.class));
-        then(articleRepository).should().findAll();
+        if(searchType == null){
+            given(articleRepository.findAll()).willReturn(new ArrayList<Article>());
+
+            articleService.searchArticle(param);
+
+            then(articleRepository).should().findAll();
+        } else if (searchType == SearchType.TITLE) {
+            given(articleRepository.findByTitle(anyString())).willReturn(new ArrayList<Article>());
+
+            articleService.searchArticle(param);
+
+            then(articleRepository).should().findByTitle(any(String.class));
+        }
+
+    }
+
+    static Stream<Arguments> searchByTitleTest(){
+        return Stream.of(
+                arguments("Valid SearchType", SearchType.TITLE, "title1"),
+                arguments("Short SearchKeyword", SearchType.TITLE, ""),
+                arguments("No SearchType", null, null),
+                arguments("No SearchType and Use keyword", null, "keyword")
+        );
     }
 }


### PR DESCRIPTION
이번 미션에서 가장 고민을 많이했던 부분이었습니다.
1. SearchType의 상태에 따라 SearchKeyword에 대한 검증이 이뤄져야 하다보니 애노테이션을 이용한 Bean Validation적용이 어려웠습니다.(애노테이션을 이용한 해결방법이 있다면 알려주시면 감사하겠습니다.)
2. 이를 해결하기 위해 기존에 Controller에 전달되던 SearchType과 SearchKeyword는 변수를  SearchRequestDto로 통합 
3. 검색 조건에 대한 입력값 검증을 위해 검증기를 별도 구현(SearchValidator)
4. SearchRequestDto에서 @Setter를 뺐더니 정상적으로 검증기능을 하지 않아 전역 @Setter는 유지

To리뷰어
1. 현재 로직상 searchKeyword가 searchType의 유무에 따라 검증을 받다보니 애노테이션을 이용한 입력값 검증이 불가능한 것 같았습니다. 이 방법 말고도 더 적절한 방법이 있을지 피드백 부탁드립니다.
2. 입력값에 대해 Controller의 검증기에 의존하고 Service, Repository에서는 검증하고 있지 않습니다. (서비스코드 37번줄에서 searchRequestDto.getSearchType()의 NPE발생 가능성 배제). 
   어차피 사용자 입력값은 controller가 조작하기 때문에 그 이외의 코드에서는 controller에 에러체크를 위임했다고 생각했습니다. 
    그럼에도 Optional등을 사용해서 코드 안정성을 높이는 게 더 나을까요?
3. ArticleServiceUnitTest 53줄~ 게시물 검색 관련 테스트 코드입니다. 코드 내에서 분기문을 사용하고 있는데, 테스트코드 작성 시 코드 내에 분기문 사용은 적절하지 않다고 들었습니다. 그럼에도 검색 조건에 따라 적절한 검색 메소드가 호출되는지를 하나의 테스트에서 확인하는 게 적절하다고 생각해 분기문을 사용했습니다. 리뷰어 분들은 동일한 상황에서 각 조건에 따른 검색 테스트를 따로 구현하셨을까요?

@jaeseongDev @mog-hi 