### PR TITLE
refactor : ErrorCode 및 ErrorResponse를 이용하여 오류코드 전송 양식 통일

### DIFF
--- a/src/main/java/com/jscode/demoApp/dto/response/ErrorResponseDto.java
+++ b/src/main/java/com/jscode/demoApp/dto/response/ErrorResponseDto.java
@@ -1,0 +1,27 @@
+package com.jscode.demoApp.dto.response;
+
+import com.jscode.demoApp.error.ErrorCode;
+import lombok.*;
+
+@ToString
+@NoArgsConstructor
+@Getter
+public class ErrorResponseDto {
+    private String code;
+    private String message;
+    private Object messageDetail;
+
+    private ErrorResponseDto(String code, String message, Object messageDetail){
+        this.code = code;
+        this.message = message;
+        this.messageDetail = messageDetail;
+    }
+
+    public static ErrorResponseDto of(ErrorCode errorCode){
+        return new ErrorResponseDto(errorCode.getCode(), errorCode.getMessage(), null);
+    }
+
+    public static ErrorResponseDto of(ErrorCode errorCode, Object messageDetail){
+        return new ErrorResponseDto(errorCode.getCode(), errorCode.getMessage(), messageDetail);
+    }
+}

--- a/src/main/java/com/jscode/demoApp/error/ErrorCode.java
+++ b/src/main/java/com/jscode/demoApp/error/ErrorCode.java
@@ -1,0 +1,22 @@
+package com.jscode.demoApp.error;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public enum ErrorCode {
+
+    RESOURCE_NOT_FOUND(HttpStatus.NOT_FOUND, "A-S-001", "게시글이 존재하지 않습니다."), //Article Service Error : 게시글이 존재하지 않음
+    INVALID_REQUEST_ENCODE(HttpStatus.BAD_REQUEST, "A-C-001", "JSON 형식 요청이 아닙니다."), //Article Controller Error1 : Request 인코딩 형식 오류
+    REQUEST_FIELD_ERROR(HttpStatus.BAD_REQUEST, "A-C-002", "입력 필드에 오류가 있습니다."); //Article Controller Error2 : Request 필드 검증 실패
+    private HttpStatus status;
+    private String code;
+    private String message;
+
+    ErrorCode(HttpStatus status, String code, String message){
+        this.status = status;
+        this.code = code;
+        this.message = message;
+    }
+
+}

--- a/src/main/java/com/jscode/demoApp/error/advice/ArticleAdvice.java
+++ b/src/main/java/com/jscode/demoApp/error/advice/ArticleAdvice.java
@@ -1,35 +1,93 @@
 package com.jscode.demoApp.error.advice;
 
 import com.jscode.demoApp.controller.ArticleController;
-import org.hibernate.TypeMismatchException;
+import com.jscode.demoApp.dto.response.ErrorResponseDto;
+import com.jscode.demoApp.error.ErrorCode;
+import com.jscode.demoApp.error.exception.FieldBindingException;
+import com.jscode.demoApp.error.exception.ResourceNotFoundException;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.validation.BindException;
+import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 import javax.persistence.EntityNotFoundException;
+import java.util.*;
 
+@Slf4j
 @RestControllerAdvice(assignableTypes = ArticleController.class)
 public class ArticleAdvice {
-    @ResponseStatus(HttpStatus.NOT_FOUND)
-    @ExceptionHandler(EntityNotFoundException.class)
-    public String entityExHandler(EntityNotFoundException ex){
+    ErrorResponseDto errorResponseDto;
+    //@ResponseStatus(HttpStatus.NOT_FOUND) annotation이 있더라도 response에서 상태코드를 지정하면 response 상태 코드가 우선임
+    @ExceptionHandler(ResourceNotFoundException.class)
+    public ResponseEntity resourceNotFountExHandler(ResourceNotFoundException ex){
         //todo: API인 점을 고려해서 문자열보다는 부호화된 코드를 보내는 걸로 refactor필요
-        return ex.getMessage();
+        errorResponseDto = ErrorResponseDto.of(ex.getErrorCode());
+        return ResponseEntity.status(ex.getStatus()).body(Optional.of(errorResponseDto));
     }
 
     //@RequestBody에 text/html형식 데이터가 올 때
-    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    /*HttpMessageConverter에서 throw하는 Exception이다보니 Custom Exception을 적용할 수 없다.
+      그러다보니 위 메소드와 동일한 방식으로 처리 제한
+     */
     @ExceptionHandler(HttpMessageNotReadableException.class)
-    public String messageNotReadableExHandler(HttpMessageNotReadableException ex){
+    public ResponseEntity messageNotReadableExHandler(HttpMessageNotReadableException ex){
+        errorResponseDto = ErrorResponseDto.of(ErrorCode.INVALID_REQUEST_ENCODE);
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errorResponseDto);
+    }
 
-        return "JSON형식으로 보내주세요.";
+
+    @ExceptionHandler(BindException.class)
+    public ResponseEntity bindingExExHandler(BindException ex){
+        /*
+            bindingResult의 값을 errors Map에 담아 응답으로 보내준다.
+            {에러 필드명1 : {에러 정보1, 에러 정보 2}, 에러 필드명2: {에러 정보1, 에러 정보2}라는
+            형식으로 json응답을 보내고 싶을 때 Map을 쓰지 앟는 더 적절한 방법이 있을까?
+            컨트롤러에서 여러 번 사용될 것 같으므로 별도 코드로 빼는 게 더 좋을 듯 하다.
+         */
+
+        Map<String, List<String>> messageDetail = new HashMap<>();
+        BindingResult bindingResult = ex.getBindingResult();
+
+        if(bindingResult.hasErrors()){
+            bindingResult.getFieldErrors()
+                    .forEach(e -> messageDetail
+                            .computeIfAbsent(e.getField(), key -> new ArrayList<String>())
+                            .add(e.getDefaultMessage()));
+        }
+
+        errorResponseDto = ErrorResponseDto.of(ErrorCode.INVALID_REQUEST_ENCODE, messageDetail);
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errorResponseDto);
+    }
+
+    @ExceptionHandler(FieldBindingException.class)
+    public ResponseEntity FieldBindingExExHandler(FieldBindingException ex){
+        /*
+            bindingResult의 값을 errors Map에 담아 응답으로 보내준다.
+            {에러 필드명1 : {에러 정보1, 에러 정보 2}, 에러 필드명2: {에러 정보1, 에러 정보2}라는
+            형식으로 json응답을 보내고 싶을 때 Map을 쓰지 앟는 더 적절한 방법이 있을까?
+            컨트롤러에서 여러 번 사용될 것 같으므로 별도 코드로 빼는 게 더 좋을 듯 하다.
+         */
+
+        Map<String, List<String>> messageDetail = new HashMap<>();
+        BindingResult bindingResult = ex.getBindingResult();
+        if(bindingResult.hasErrors()){
+            bindingResult.getFieldErrors()
+                    .forEach(e -> messageDetail
+                            .computeIfAbsent(e.getField(), key -> new ArrayList<String>())
+                            .add(e.getDefaultMessage()));
+        }
+
+        errorResponseDto = ErrorResponseDto.of(ErrorCode.INVALID_REQUEST_ENCODE, messageDetail);
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errorResponseDto);
     }
 
     //검색 타입을 잘못지정하였을 때
-
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     @ExceptionHandler
     public void illegalArgumentExHandler(IllegalArgumentException ex){

--- a/src/main/java/com/jscode/demoApp/error/exception/CustomErrorException.java
+++ b/src/main/java/com/jscode/demoApp/error/exception/CustomErrorException.java
@@ -1,0 +1,27 @@
+package com.jscode.demoApp.error.exception;
+
+import com.jscode.demoApp.error.ErrorCode;
+import org.springframework.http.HttpStatus;
+
+public class CustomErrorException extends RuntimeException {
+    ErrorCode errorCode;
+
+    public CustomErrorException(ErrorCode errorCode){
+        this.errorCode = errorCode;
+    }
+
+    public ErrorCode getErrorCode(){
+        return this.errorCode;
+    }
+    public String getCode(){
+        return this.errorCode.getCode();
+    }
+
+    public String getMessage(){
+        return this.errorCode.getMessage();
+    }
+
+    public HttpStatus getStatus(){
+        return this.errorCode.getStatus();
+    }
+}

--- a/src/main/java/com/jscode/demoApp/error/exception/FieldBindingException.java
+++ b/src/main/java/com/jscode/demoApp/error/exception/FieldBindingException.java
@@ -1,0 +1,16 @@
+package com.jscode.demoApp.error.exception;
+
+import com.jscode.demoApp.error.ErrorCode;
+import org.springframework.validation.BindingResult;
+
+public class FieldBindingException extends CustomErrorException{
+    BindingResult bindingResult;
+    public FieldBindingException(ErrorCode errorCode, BindingResult bindingResult){
+        super(errorCode);
+        this.bindingResult = bindingResult;
+    }
+
+    public BindingResult getBindingResult() {
+        return bindingResult;
+    }
+}

--- a/src/main/java/com/jscode/demoApp/error/exception/ResourceNotFoundException.java
+++ b/src/main/java/com/jscode/demoApp/error/exception/ResourceNotFoundException.java
@@ -1,0 +1,9 @@
+package com.jscode.demoApp.error.exception;
+
+import com.jscode.demoApp.error.ErrorCode;
+
+public class ResourceNotFoundException extends CustomErrorException {
+    public ResourceNotFoundException(ErrorCode errorCode){
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/jscode/demoApp/service/ArticleService.java
+++ b/src/main/java/com/jscode/demoApp/service/ArticleService.java
@@ -4,6 +4,8 @@ import com.jscode.demoApp.constant.SearchType;
 import com.jscode.demoApp.domain.Article;
 import com.jscode.demoApp.dto.ArticleDto;
 import com.jscode.demoApp.dto.request.SearchRequestDto;
+import com.jscode.demoApp.error.ErrorCode;
+import com.jscode.demoApp.error.exception.ResourceNotFoundException;
 import com.jscode.demoApp.repository.ArticleRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -24,7 +26,7 @@ public class ArticleService {
     public ArticleDto getArticle(Long id){
         Article article = articleRepository.findById(id)
                 .orElseThrow(() -> {
-            throw new EntityNotFoundException("게시글이 존재하지 않습니다");
+            throw new ResourceNotFoundException(ErrorCode.RESOURCE_NOT_FOUND);
             //아래 코드로도 예외처리 가능
             //throw new ResponseStatusException(HttpStatus.NOT_FOUND, "게시글이 존재하지 않습니다.", new EntityNotFoundException());
         });
@@ -63,7 +65,7 @@ public class ArticleService {
         //Todo : findById() 메소드 자체에서 값이 없을 경우 EntityNotFoundException을 throw하면 코드 중복을 줄일 수 있을 듯 하다.
         Article article = articleRepository.findById(id)
                 .orElseThrow(() -> {
-                    throw new EntityNotFoundException("해당 게시글은 존재하지 않습니다");
+                    throw new ResourceNotFoundException(ErrorCode.RESOURCE_NOT_FOUND);
                 });
         articleRepository.delete(article);
     }
@@ -71,7 +73,7 @@ public class ArticleService {
     public ArticleDto updateArticle(ArticleDto articleDto){
         Article article = articleRepository.findById(articleDto.getId())
                 .orElseThrow(() -> {
-                    throw new EntityNotFoundException("해당 게시글은 존재하지 않습니다");
+                    throw new ResourceNotFoundException(ErrorCode.RESOURCE_NOT_FOUND);
                 });
         article.update(articleDto.getTitle(), articleDto.getContent());
         return ArticleDto.fromEntity(article);

--- a/src/test/java/com/jscode/demoApp/controller/ArticleControllerTest.java
+++ b/src/test/java/com/jscode/demoApp/controller/ArticleControllerTest.java
@@ -8,6 +8,8 @@ import com.jscode.demoApp.dto.ArticleDto;
 import com.jscode.demoApp.dto.request.ArticleRequestDto;
 import com.jscode.demoApp.dto.request.SearchRequestDto;
 import com.jscode.demoApp.dto.response.ArticleResponseDto;
+import com.jscode.demoApp.error.ErrorCode;
+import com.jscode.demoApp.error.exception.ResourceNotFoundException;
 import com.jscode.demoApp.service.ArticleService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -66,7 +68,7 @@ public class ArticleControllerTest {
     @DisplayName("[GET]게시글 Id 이용 조회 테스트(게시글 X)")
     public void getArticleFailTest() throws Exception {
 
-        given(articleService.getArticle(any(Long.class))).willThrow(new EntityNotFoundException());
+        given(articleService.getArticle(any(Long.class))).willThrow(new ResourceNotFoundException(ErrorCode.RESOURCE_NOT_FOUND));
 
         mvc.perform(get("/articles/100")
                         .accept(MediaType.APPLICATION_JSON_VALUE))
@@ -112,7 +114,7 @@ public class ArticleControllerTest {
         mvc.perform(get("/articles")
                         .queryParams(param))
                 .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.*", hasSize(1)))
+                .andExpect(jsonPath("$.*", hasSize(3)))
                 .andDo(print());
     }
 
@@ -171,11 +173,11 @@ public class ArticleControllerTest {
         MultiValueMap<String, String> param = new LinkedMultiValueMap<>();
         param.add("title", title);
         param.add("content", content);
-
+        //Todo : 에러 필드 구체적으로 검사하도록 테스트코드 수정 필요
         mvc.perform(post("/articles/form")
                     .params(param))
                 .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.*", hasSize(numOfErrors)))
+                .andExpect(jsonPath("$.*", hasSize(3)))
                 .andDo(print());
 
     }
@@ -210,7 +212,7 @@ public class ArticleControllerTest {
     @DisplayName("[DELETE]게시물 삭제 테스트(게시글 X)")
     @Test
     public void deleteArticleFailTest() throws Exception{
-        willThrow(EntityNotFoundException.class).given(articleService).deleteArticle(any(Long.class));
+        willThrow(new ResourceNotFoundException(ErrorCode.RESOURCE_NOT_FOUND)).given(articleService).deleteArticle(any(Long.class));
 
         mvc.perform(delete("/articles/1"))
                 .andExpect(status().isNotFound());
@@ -244,7 +246,7 @@ public class ArticleControllerTest {
         param.put("content", "content");
 
 
-        given(articleService.updateArticle(any(ArticleDto.class))).willThrow(new EntityNotFoundException());
+        given(articleService.updateArticle(any(ArticleDto.class))).willThrow(new ResourceNotFoundException(ErrorCode.RESOURCE_NOT_FOUND));
 
         mvc.perform(put("/articles/1")
                         .contentType(MediaType.APPLICATION_JSON)
@@ -269,7 +271,7 @@ public class ArticleControllerTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(request.writeValueAsString(param)))
                 .andExpect(status().isBadRequest())
-                .andExpect(content().string("JSON형식으로 보내주세요."))
+                .andExpect(jsonPath("$.code").value("A-C-001"))
                 .andDo(print());
     }
 
@@ -280,7 +282,7 @@ public class ArticleControllerTest {
 
         mvc.perform(put("/articles/1"))
                 .andExpect(status().isBadRequest())
-                .andExpect(content().string("JSON형식으로 보내주세요."))
+                .andExpect(jsonPath("$.code").value("A-C-001"))
                 .andDo(print());
     }
 /*


### PR DESCRIPTION
- [x] Enum 이용 ErrorCode 관리

- [x] ErrorResponse에서는 code, message, messageDetail 필드를 이용해 API통신에 이용될 오류코드, 오류 종류, 오류 상세 내용을 전송

- [x] Controller에서는 BindingResult를 직접 사용하는 방법과 ExceptionHandler를 이용해 처리하는 방법 모두 사용

- [x] Service레이어에서 Enum ErrorCode을 이용하도록 수정
this closes #26 